### PR TITLE
Add Prowlarr addon

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -428,6 +428,15 @@ DEFAULT_JACKETTIO_STREMTHRU_URL=https://stremthru.13377001.xyz
 # FORCE_JACKETTIO_PORT=
 # FORCE_JACKETTIO_PROTOCOL=
 
+# ----------- PROWLARR -------------
+PROWLARR_URL=https://prowlarr.elfhosted.com/
+# DEFAULT_PROWLARR_TIMEOUT=
+DEFAULT_PROWLARR_INDEXERS='["eztv", "thepiratebay", "therarbg", "yts"]'
+DEFAULT_PROWLARR_STREMTHRU_URL=https://stremthru.13377001.xyz
+# FORCE_PROWLARR_HOSTNAME=
+# FORCE_PROWLARR_PORT=
+# FORCE_PROWLARR_PROTOCOL=
+
 # --------- STREMTHRU-STORE ---------
 STREMTHRU_STORE_URL=https://stremthru.elfhosted.com/stremio/store/
 # DEFAULT_STREMTHRU_STORE_TIMEOUT=

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ AIOStreams integrates results from, and has automated configuration for, the fol
 - Torbox Addon
 - Debridio
 - Jackettio / Stremio-Jackett
+- Prowlarr
 - Peerflix
 - DMM Cast
 - Orion Stremio Addon
@@ -81,6 +82,7 @@ There are several ways to use AIOStreams:
 2. 🛠️ **Self-Hosting / Paid Hosting:**
    - Host AIOStreams yourself using methods like Docker, Cloudflare Workers, or directly from the source.
    - Use a paid hosting provider like [ElfHosted](https://store.elfhosted.com/product/aiostreams/elf/viren070/) (using this link supports the project!) or Heroku.
+   - To enable the new **Prowlarr** addon, set `PROWLARR_URL` in your `.env` file to the address of your instance and supply the API key when configuring the addon. Streams from Prowlarr will be passed to Torbox or any other enabled debrid service for downloading.
 
 > [!NOTE]
 > A [private ElfHosted instance](https://store.elfhosted.com/product/aiostreams/elf/viren070/) will support all addons, including Torrentio, avoid ratelimits of all ElfHosted addons, and also have no rate limit of its own.

--- a/packages/core/src/presets/presetManager.ts
+++ b/packages/core/src/presets/presetManager.ts
@@ -16,6 +16,7 @@ import { PeerflixPreset } from './peerflix';
 import { DMMCastPreset } from './dmmCast';
 import { MarvelPreset } from './marvel';
 import { JackettioPreset } from './jackettio';
+import { ProwlarrPreset } from './prowlarr';
 import { OrionPreset } from './orion';
 import { StreamFusionPreset } from './streamfusion';
 import { AnimeKitsuPreset } from './animeKitsu';
@@ -43,6 +44,7 @@ const PRESET_LIST: string[] = [
   'stremthruStore',
   'torbox',
   'jackettio',
+  'prowlarr',
   'peerflix',
   'easynews',
   'easynewsPlus',
@@ -106,6 +108,8 @@ export class PresetManager {
         return TorboxAddonPreset;
       case 'jackettio':
         return JackettioPreset;
+      case 'prowlarr':
+        return ProwlarrPreset;
       case 'easynews':
         return EasynewsPreset;
       case 'easynewsPlus':

--- a/packages/core/src/presets/prowlarr.ts
+++ b/packages/core/src/presets/prowlarr.ts
@@ -1,0 +1,204 @@
+import { Addon, Option, UserData, Resource } from '../db';
+import { baseOptions, Preset } from './preset';
+import { Env } from '../utils';
+import { constants, ServiceId } from '../utils';
+import { StreamParser } from '../parser';
+
+class ProwlarrStreamParser extends StreamParser {
+  override applyUrlModifications(url: string | undefined): string | undefined {
+    if (!url) {
+      return url;
+    }
+    if (
+      Env.FORCE_PROWLARR_HOSTNAME !== undefined ||
+      Env.FORCE_PROWLARR_PORT !== undefined ||
+      Env.FORCE_PROWLARR_PROTOCOL !== undefined
+    ) {
+      // modify the URL according to settings, needed when using a local URL for requests but a public stream URL is needed.
+      const urlObj = new URL(url);
+
+      if (Env.FORCE_PROWLARR_PROTOCOL !== undefined) {
+        urlObj.protocol = Env.FORCE_PROWLARR_PROTOCOL;
+      }
+      if (Env.FORCE_PROWLARR_PORT !== undefined) {
+        urlObj.port = Env.FORCE_PROWLARR_PORT.toString();
+      }
+      if (Env.FORCE_PROWLARR_HOSTNAME !== undefined) {
+        urlObj.hostname = Env.FORCE_PROWLARR_HOSTNAME;
+      }
+      return urlObj.toString();
+    }
+    return url;
+  }
+}
+
+export class ProwlarrPreset extends Preset {
+  static override getParser(): typeof StreamParser {
+    return ProwlarrStreamParser;
+  }
+
+  static override get METADATA() {
+    const supportedServices: ServiceId[] = [
+      constants.REALDEBRID_SERVICE,
+      constants.PREMIUMIZE_SERVICE,
+      constants.ALLEDEBRID_SERVICE,
+      constants.TORBOX_SERVICE,
+      constants.EASYDEBRID_SERVICE,
+      constants.DEBRIDLINK_SERVICE,
+      constants.OFFCLOUD_SERVICE,
+      constants.PIKPAK_SERVICE,
+    ];
+
+    const supportedResources = [constants.STREAM_RESOURCE];
+
+    const options: Option[] = [
+      ...baseOptions(
+        'Prowlarr',
+        supportedResources,
+        Env.DEFAULT_PROWLARR_TIMEOUT
+      ),
+      {
+        id: 'services',
+        name: 'Services',
+        description:
+          'Optionally override the services that are used. If not specified, then the services that are enabled and supported will be used.',
+        type: 'multi-select',
+        required: false,
+        options: supportedServices.map((service) => ({
+          value: service,
+          label: constants.SERVICE_DETAILS[service].name,
+        })),
+        default: undefined,
+        emptyIsUndefined: true,
+      },
+      {
+        id: 'apiKey',
+        name: 'API Key',
+        description: 'Your Prowlarr API key',
+        type: 'password',
+        required: true,
+      },
+      {
+        id: 'socials',
+        name: '',
+        description: '',
+        type: 'socials',
+        socials: [
+          { id: 'github', url: 'https://github.com/Telkaoss/prowlarr' },
+        ],
+      },
+    ];
+
+    return {
+      ID: 'prowlarr',
+      NAME: 'Prowlarr',
+      LOGO: 'https://raw.githubusercontent.com/Jackett/Jackett/bbea5febd623f6e536e11aa1fa8d6674d8d4043f/src/Jackett.Common/Content/jacket_medium.png',
+      URL: Env.PROWLARR_URL,
+      TIMEOUT: Env.DEFAULT_PROWLARR_TIMEOUT || Env.DEFAULT_TIMEOUT,
+      USER_AGENT: Env.DEFAULT_PROWLARR_USER_AGENT || Env.DEFAULT_USER_AGENT,
+      SUPPORTED_SERVICES: supportedServices,
+      DESCRIPTION:
+        'Stremio addon that resolves streams using Prowlarr and Debrid',
+      OPTIONS: options,
+      SUPPORTED_STREAM_TYPES: [constants.DEBRID_STREAM_TYPE],
+      SUPPORTED_RESOURCES: supportedResources,
+    };
+  }
+
+  static async generateAddons(
+    userData: UserData,
+    options: Record<string, any>
+  ): Promise<Addon[]> {
+    if (options?.url?.endsWith('/manifest.json')) {
+      return [this.generateAddon(userData, options, undefined)];
+    }
+
+    const usableServices = this.getUsableServices(userData, options.services);
+    if (!usableServices || usableServices.length === 0) {
+      throw new Error(
+        `${this.METADATA.NAME} requires at least one usable service from the list of supported services: ${this.METADATA.SUPPORTED_SERVICES.map((service) => constants.SERVICE_DETAILS[service].name).join(', ')}`
+      );
+    }
+
+    let addons = usableServices.map((service) =>
+      this.generateAddon(userData, options, service.id)
+    );
+
+    return addons;
+  }
+
+  private static generateAddon(
+    userData: UserData,
+    options: Record<string, any>,
+    serviceId?: ServiceId
+  ): Addon {
+    return {
+      name: options.name || this.METADATA.NAME,
+      identifier: serviceId
+        ? `${constants.SERVICE_DETAILS[serviceId].shortName}`
+        : undefined, // when no service is provided - its either going to fail or be a custom addon, which is only 1 addon in either case
+      displayIdentifier: serviceId
+        ? `${constants.SERVICE_DETAILS[serviceId].shortName}`
+        : undefined,
+      manifestUrl: this.generateManifestUrl(userData, options, serviceId),
+      enabled: true,
+      resources: options.resources || this.METADATA.SUPPORTED_RESOURCES,
+      timeout: options.timeout || this.METADATA.TIMEOUT,
+      presetType: this.METADATA.ID,
+      presetInstanceId: '',
+      headers: {
+        'User-Agent': this.METADATA.USER_AGENT,
+      },
+    };
+  }
+
+  private static generateManifestUrl(
+    userData: UserData,
+    options: Record<string, any>,
+    serviceId: ServiceId | undefined
+  ) {
+    let url = options.url || this.METADATA.URL;
+    if (url.endsWith('/manifest.json')) {
+      return url;
+    }
+    if (!serviceId) {
+      throw new Error(
+        `${this.METADATA.NAME} requires at least one usable service from the list of supported services: ${this.METADATA.SUPPORTED_SERVICES.map((service) => constants.SERVICE_DETAILS[service].name).join(', ')}`
+      );
+    }
+    url = url.replace(/\/$/, '');
+    const configString = this.base64EncodeJSON({
+      apiKey: options.apiKey,
+      maxTorrents: 30,
+      priotizePackTorrents: 2,
+      excludeKeywords: [],
+      debridId: serviceId,
+      debridApiKey: this.getServiceCredential(serviceId, userData, {
+        [constants.OFFCLOUD_SERVICE]: (credentials: any) =>
+          `${credentials.email}:${credentials.password}`,
+        [constants.PIKPAK_SERVICE]: (credentials: any) =>
+          `${credentials.email}:${credentials.password}`,
+      }),
+      hideUncached: false,
+      sortCached: [
+        ['quality', true],
+        ['size', true],
+      ],
+      sortUncached: [['seeders', true]],
+      forceCacheNextEpisode: false,
+      priotizeLanguages: [],
+      indexerTimeoutSec: 60,
+      metaLanguage: '',
+      enableMediaFlow: false,
+      mediaflowProxyUrl: '',
+      mediaflowApiPassword: '',
+      mediaflowPublicIp: '',
+      useStremThru: true,
+      stremthruUrl: Env.DEFAULT_PROWLARR_STREMTHRU_URL,
+      qualities: [0, 360, 480, 720, 1080, 2160],
+      indexers: Env.DEFAULT_PROWLARR_INDEXERS,
+    });
+
+    return `${url}${configString ? '/' + configString : ''}/manifest.json`;
+  }
+}

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -676,6 +676,41 @@ export const Env = cleanEnv(process.env, {
     desc: 'Default Jackettio user agent',
   }),
 
+  // Prowlarr settings
+  PROWLARR_URL: url({
+    default: 'https://prowlarr.elfhosted.com',
+    desc: 'Prowlarr URL',
+  }),
+  DEFAULT_PROWLARR_INDEXERS: json({
+    default: ['eztv', 'thepiratebay', 'therarbg', 'yts'],
+    desc: 'Default Prowlarr indexers',
+  }),
+  DEFAULT_PROWLARR_STREMTHRU_URL: url({
+    default: 'https://stremthru.13377001.xyz',
+    desc: 'Default Prowlarr StremThru URL',
+  }),
+  DEFAULT_PROWLARR_TIMEOUT: num({
+    default: undefined,
+    desc: 'Default Prowlarr timeout',
+  }),
+  FORCE_PROWLARR_HOSTNAME: host({
+    default: undefined,
+    desc: 'Force Prowlarr hostname',
+  }),
+  FORCE_PROWLARR_PORT: forcedPort({
+    default: undefined,
+    desc: 'Force Prowlarr port',
+  }),
+  FORCE_PROWLARR_PROTOCOL: str({
+    default: undefined,
+    desc: 'Force Prowlarr protocol',
+    choices: ['http', 'https'],
+  }),
+  DEFAULT_PROWLARR_USER_AGENT: userAgent({
+    default: undefined,
+    desc: 'Default Prowlarr user agent',
+  }),
+
   // Torrentio settings
   TORRENTIO_URL: url({
     default: 'https://torrentio.strem.fun',


### PR DESCRIPTION
## Summary
- support Prowlarr addon with custom URL and API key
- add Prowlarr env vars
- document Prowlarr setup in README
- update example `.env`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685448d607c883298e1581357fc4acc1